### PR TITLE
Get Travis Working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: node_js
+  - "9.6.1"
+
 services:
   - mongodb
 
 before_script:
   - npm run makedb
-  
+
 cache:
   directories:
     - "node_modules"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
   - mongodb
 
 before_script:
-  - npm run makedb
+  - npm run makedb localhost
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
   - "9.6.1"
 
+install:
+  - npm install
+
 services:
   - mongodb
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,6 @@ before_script:
 cache:
   directories:
     - "node_modules"
+
+script:
+  - npm run test

--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@
 
 [![Build Status](https://travis-ci.org/leopoldodonnell/node-mongo-express.svg?branch=master)](https://travis-ci.org/leopoldodonnell/node-mongo-express)
 
-[![Known Vulnerabilities](https://snyk.io/test/github/{username}/{repo}/badge.svg)](https://snyk.io/test/github/{username}/{repo})
+[![Known Vulnerabilities](https://snyk.io/test/github/leopoldodonnell/node-mongo-express/badge.svg)](https://snyk.io/test/github/leopoldodonnell/node-mongo-express)
 
 This project is a simplistic started for working with Node, Mongo and Express with CI using TravisCI and dependency Security with Snyk.
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,21 +1,40 @@
 
-Create a docker network for node to talk to mongo
+# Node Mongo Express
+
+[![Build Status](https://travis-ci.org/leopoldodonnell/node-mongo-express.svg?branch=master)](https://travis-ci.org/leopoldodonnell/node-mongo-express)
+
+[![Known Vulnerabilities](https://snyk.io/test/github/{username}/{repo}/badge.svg)](https://snyk.io/test/github/{username}/{repo})
+
+This project is a simplistic started for working with Node, Mongo and Express with CI using TravisCI and dependency Security with Snyk.
+
+TODO: Add more discussion
+
+## On-going development with Docker
+
+TODO: Add more discussion
+
+If you haven't installed `Node` on your development machine, you can still develop using `Docker`. In this example
+you'll create a network for your containers to connect no, then run `Mongo` using a docker daemon and an interactive
+`Node` shell container on your current directory to do your development.
+
+
+1. Create a docker network for node to talk to mongo
 
 ```bash
 $ docker create network mongo-net
 ```
 
-Run an insecure mondodb instance that will dissappear on a kill
+2. Run an insecure mondodb instance that will dissappear on a kill
 ```bash
 $ docker run --rm -d --name mongo-serv --network mongo-net mongo
 ```
 
-Run the node development container
+3. Run the node development container
 ```
 $ docker run --rm -ti -v $PWD:/app -w /app --network mongo-net -p 3000:3000 node:slim /bin/bash
 root@xxxxxxx:/app# npm run dev
 ```
 
+## TravisCI integratin
 
-
-
+TODO: Add more discussion

--- a/makedb.js
+++ b/makedb.js
@@ -1,6 +1,11 @@
 const MongoClient = require('mongodb').MongoClient
 
-var mongoURL = "mongodb://mongo-serv/star-wars-quotes"
+var host = process.argv[2] || 'mongo-serv'
+
+
+var mongoURL = `mongodb://${host}/star-wars-quotes`
+
+console.log(`Creating database: ${mongoURL}`)
 
 MongoClient.connect(mongoURL, (err, database) => {
     // ... start the server

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "nodemon": "^1.15.1"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "echo \"Error: no test specified\" && exit 0",
     "makedb": "node makedb.js",
     "dev": "nodemon server.js"
   },


### PR DESCRIPTION
Make changes to get Travis-ci working

- Use specific Node release
- Update makedb to take a hostname 'localhost' for travis
- Call the test script to avoid the `rake` default.
- Make the test script succeed for now